### PR TITLE
ユーザーページの改善

### DIFF
--- a/src/pages/UserPage.vue
+++ b/src/pages/UserPage.vue
@@ -9,11 +9,21 @@ import UserDetailContainer from '/@/components/User/UserDetailContainer.vue'
 import apis from '/@/lib/apis'
 import useParam from '/@/lib/param'
 
-const userId = useParam('userId')
-const userDetail = (await apis.getUser(userId.value)).data
-const userProjects = (await apis.getUserProjects(userId.value)).data
-const userContests = (await apis.getUserContests(userId.value)).data
-const userGroups = (await apis.getUserGroups(userId.value)).data
+const userUId = useParam('userId')
+// uuid
+const userId = (await apis.getUsers(undefined, userUId.value)).data[0]?.id ?? ''
+
+const [
+  { data: userDetail },
+  { data: userProjects },
+  { data: userContests },
+  { data: userGroups }
+] = await Promise.all([
+  apis.getUser(userId),
+  apis.getUserProjects(userId),
+  apis.getUserContests(userId),
+  apis.getUserGroups(userId)
+])
 // const userEvents = (await apis.getUserEvents(userId.value)).data
 </script>
 


### PR DESCRIPTION
close https://github.com/traPtitech/traPortfolio-UI/issues/151
/users/:uuidを/users/:uidにしたのと、ユーザー関連のデータを直列で取得してたのを並列で取得できるように

before
![image](https://github.com/traPtitech/traPortfolio-UI/assets/83744975/569a3729-49d6-4ab5-9eb6-6334aacada18)
after
![image](https://github.com/traPtitech/traPortfolio-UI/assets/83744975/fe076fec-a499-48ba-b9a9-8091e57ce2f4)