### PR TITLE
ユーザー検索結果画面からユーザーページに飛べない問題の改善

### DIFF
--- a/src/components/Search/UserListItem.vue
+++ b/src/components/Search/UserListItem.vue
@@ -9,7 +9,7 @@ defineProps<{
 
 <template>
   <li>
-    <router-link :class="$style.link" :to="`/users/${member.id}`">
+    <router-link :class="$style.link" :to="`/users/${member.name}`">
       <user-icon :class="$style.icon" :user-name="member.name" :size="32" />
       <p :class="$style.name">{{ member.name }}</p>
     </router-link>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- ユーザー検索結果画面からユーザーページに飛べない問題を修正
- `router-link`の`to`属性を`member.id`から`member.name`に変更


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserListItem.vue</strong><dd><code>`router-link`の`to`属性を修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Search/UserListItem.vue

- `router-link`の`to`属性を`member.id`から`member.name`に変更



</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-UI/pull/186/files#diff-6b237bcf82ce3e780ddb2200e83c07861e347702ef1a42c8ce4a80f49de708d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

