### PR TITLE
コンテストチームの複数表示に対応

### DIFF
--- a/src/components/User/ContestsContainer.vue
+++ b/src/components/User/ContestsContainer.vue
@@ -14,10 +14,15 @@ defineProps<Props>()
     <ul v-if="contests.length > 0" :class="$style.contests">
       <li v-for="contest in contests" :key="contest.id" :class="$style.contest">
         <router-link :to="`/contests/${contest.id}`" :class="$style.link">
-          <div>{{ contest.name }}</div>
-          <div :class="$style.detail">
-            <div>チーム {{ contest.teams[0]?.name }}</div>
-            <div>{{ contest.teams[0]?.result }}</div>
+          <h4>{{ contest.name }}</h4>
+          <div
+            v-for="team in contest.teams"
+            :key="team.id"
+            :class="$style.detail"
+          >
+            チーム {{ team.name }}
+            <br />
+            {{ team.result }}
           </div>
         </router-link>
       </li>
@@ -50,12 +55,14 @@ defineProps<Props>()
 .link {
   color: $color-text;
   text-decoration: none;
+  margin: 4px 0;
 }
 .detail {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  padding-left: 0.75rem;
+  padding-left: 1.75rem;
   font-size: 0.875rem;
+  text-indent: -1rem;
 }
 </style>


### PR DESCRIPTION
### **User description**
確認お願いします〜

変更前
<img width="563" alt="image" src="https://github.com/traPtitech/traPortfolio-UI/assets/132571355/f9261138-96dd-4413-ba4d-72a5b6e5e6f1">

変更後のデザインは以下のとおりです
<img width="559" alt="image" src="https://github.com/traPtitech/traPortfolio-UI/assets/132571355/499208f2-8388-44cb-a53c-6ea0111bb29d">

close #192


___

### **PR Type**
Enhancement


___

### **Description**
- コンテストチームの複数表示に対応し、各チームの名前と結果を表示するように変更
- コンテスト名を`<h4>`タグに変更し、視覚的な階層を明確化
- CSSスタイルを微調整し、リンクのマージンと詳細情報のインデントを改善


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContestsContainer.vue</strong><dd><code>コンテストチームの複数表示とスタイル調整</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/User/ContestsContainer.vue

- コンテストチームの複数表示に対応
- コンテスト名を`<h4>`タグに変更
- CSSスタイルの微調整



</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-UI/pull/193/files#diff-91c7589f0645d5676c70ea9984b81e71f313fb7e78c94b22cd83b60b4dce7420">+12/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

