### PR TITLE
リンクが指定されていないときに表示されないようにした

### DIFF
--- a/src/pages/ContestTeamPage.vue
+++ b/src/pages/ContestTeamPage.vue
@@ -36,7 +36,10 @@ onMounted(() => {
     <div :class="$style.container">
       <div :class="$style.titleContainer">
         <page-title>チーム {{ contestTeamDetail.name }}</page-title>
-        <external-link :href="contestTeamDetail.link">
+        <external-link
+          v-if="contestTeamDetail.link"
+          :href="contestTeamDetail.link"
+        >
           説明ページ
         </external-link>
       </div>


### PR DESCRIPTION
### **User description**
close #190


___

### **PR Type**
enhancement


___

### **Description**
- `external-link` コンポーネントに `v-if` ディレクティブを追加し、`contestTeamDetail.link` が存在する場合のみリンクを表示するように変更。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContestTeamPage.vue</strong><dd><code>リンクが指定されていない場合の表示制御を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/ContestTeamPage.vue

<li><code>external-link</code> コンポーネントに <code>v-if</code> ディレクティブを追加<br> <li> <code>contestTeamDetail.link</code> が存在する場合のみリンクを表示<br>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-UI/pull/198/files#diff-b5da0d567c7468f41b0003abf32c0276aeda02e1176112e0d783703e4c704259">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

