### PR TITLE
fix: added genApi step before build image

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -11,8 +11,27 @@ env:
   IMAGE_NAME: traportfolio-ui
 
 jobs:
+  # API生成部分をDockerのビルド部分から分離
+  genApi:
+    name: Generate APIs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+      - run: npm ci
+      - run: npm run gen-api
+      - uses: actions/upload-artifact@v4
+        with:
+          name: apis
+          path: ./src/lib/apis/generated
+
   build-preview-image:
     name: Build Preview Image
+    needs:
+      - genApi
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +55,11 @@ jobs:
           registry: ghcr.io
           username: traptitech
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: apis
+          path: ./src/lib/apis/generated
 
       # Docker 内でビルドを行うことで、write perm つきでの任意コード実行を避ける
       # workflow 自体の改竄はないが、悪意のあるソースコードが入った場合に secret が抽出される可能性があるためである


### PR DESCRIPTION
### **User description**
確認お願いします〜

`release.yaml` と同じ方法に変更しただけなのでチェックは簡単だと思います

___

### **PR Type**
enhancement


___

### **Description**
- 新しいジョブ `genApi` を追加し、API生成をDockerビルドから分離しました。
- `genApi` ジョブでAPIを生成し、生成されたAPIをアーティファクトとしてアップロードするようにしました。
- `build-preview-image` ジョブで生成されたAPIをダウンロードして使用するように変更しました。
- `build-preview-image` ジョブが `genApi` ジョブに依存するように設定し、ビルドプロセスを改善しました。



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>preview.yaml</strong><dd><code>API生成ステップを追加し、ビルドプロセスを改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/preview.yaml

<li>新しいジョブ <code>genApi</code> を追加し、API生成をDockerビルドから分離<br> <li> <code>genApi</code> ジョブでAPIを生成し、生成されたAPIをアーティファクトとしてアップロード<br> <li> <code>build-preview-image</code> ジョブで生成されたAPIをダウンロードして使用<br> <li> <code>build-preview-image</code> ジョブが <code>genApi</code> ジョブに依存するように設定<br>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-UI/pull/235/files#diff-22da830e02ef5bed54ecad981722fd9c940aec797740c09927d4a904df0bccd6">+24/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information