### PR TITLE
ユーザーの情報が入力されていないときの表示を修正

### DIFF
--- a/src/components/User/ContestsContainer.vue
+++ b/src/components/User/ContestsContainer.vue
@@ -37,7 +37,7 @@ defineProps<Props>()
         </router-link>
       </li>
     </ul>
-    <p v-else>まだ実績は登録されていません</p>
+    <p v-else>実績はまだ登録されていません</p>
   </section>
 </template>
 

--- a/src/components/User/ProjectsContainer.vue
+++ b/src/components/User/ProjectsContainer.vue
@@ -16,7 +16,7 @@ defineProps<Props>()
       v-if="projects.length > 0"
       :projects="projects"
     />
-    <p v-else>これまでに参加したプロジェクトはありません</p>
+    <p v-else>これまでに参加したプロジェクトはまだ登録されていません</p>
   </section>
 </template>
 


### PR DESCRIPTION
### **User description**
fix #205


___

### **PR Type**
Enhancement


___

### **Description**
- ユーザーの実績が登録されていない場合の表示メッセージを更新しました。
- ユーザーが参加したプロジェクトが登録されていない場合の表示メッセージを更新しました。



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContestsContainer.vue</strong><dd><code>Update message for unregistered achievements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/User/ContestsContainer.vue

- Updated message for when no achievements are registered.



</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-UI/pull/245/files#diff-91c7589f0645d5676c70ea9984b81e71f313fb7e78c94b22cd83b60b4dce7420">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProjectsContainer.vue</strong><dd><code>Update message for unregistered projects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/User/ProjectsContainer.vue

- Updated message for when no projects are registered.



</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-UI/pull/245/files#diff-12f49db42d287771ee173d5606f139674f4052778e383349803222f0e473d2a6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information