### PR TITLE
プロジェクトメンバーを加入日昇順にソート

### DIFF
--- a/src/components/Project/MemberList.vue
+++ b/src/components/Project/MemberList.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { computed } from 'vue'
 import MemberListItem from './MemberListItem.vue'
 import { ProjectMember } from '/@/lib/apis'
 import SectionTitle from '/@/components/Layout/SectionTitle.vue'
@@ -7,7 +8,20 @@ interface Props {
   members: ProjectMember[]
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
+
+const sortedMembers = computed(() => {
+  if (!props.members) return []
+  const li = props.members
+  li.sort((a, b) => {
+    if (a.duration.since.year !== b.duration.since.year) {
+      return a.duration.since.year - b.duration.since.year
+    } else {
+      return a.duration.since.semester - b.duration.since.semester
+    }
+  })
+  return li
+})
 </script>
 
 <template>
@@ -15,7 +29,7 @@ defineProps<Props>()
     <section-title>プロジェクトメンバー</section-title>
     <ul :class="$style.container">
       <member-list-item
-        v-for="member in members"
+        v-for="member in sortedMembers"
         :key="member.id"
         :member="member"
       />


### PR DESCRIPTION
### **User description**
close #224


___

### **PR Type**
Enhancement


___

### **Description**
- プロジェクトメンバーを加入日昇順にソートするためのロジックを追加。
- `computed`プロパティ`sortedMembers`を作成し、`year`と`semester`を基準にメンバーをソート。
- テンプレート内で`v-for`ディレクティブを`sortedMembers`に変更し、ソートされたリストを表示。



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MemberList.vue</strong><dd><code>メンバーリストを加入日昇順にソートするロジックを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Project/MemberList.vue

<li>新しい<code>computed</code>プロパティ<code>sortedMembers</code>を追加し、メンバーを加入日昇順にソート。<br> <li> <code>v-for</code>ディレクティブで<code>members</code>の代わりに<code>sortedMembers</code>を使用。<br> <li> メンバーのソートロジックを<code>year</code>と<code>semester</code>で実装。<br>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-UI/pull/255/files#diff-2f7f2f1d34bc86f94237e30629862d5dc9b7868de15b0ea6499e1ced1c2be3dc">+16/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information